### PR TITLE
Add cloud labels to groups

### DIFF
--- a/nerdlets/cloud-optimize-nerdlet/components/menuBar.js
+++ b/nerdlets/cloud-optimize-nerdlet/components/menuBar.js
@@ -3,6 +3,8 @@ import { Menu, Dropdown, Popup } from 'semantic-ui-react'
 import Configuration from '../../shared/components/config'
 import SnapshotList from './snapshots/snapshotList'
 import PricingSelector from '../../shared/components/pricingSelector'
+import { cloudLabelAttributeToDisplayName } from '../../shared/lib/utils'
+import _ from 'lodash';
 
 export default class MenuBar extends React.Component {
 
@@ -13,8 +15,9 @@ export default class MenuBar extends React.Component {
     }
 
     async handleDropdownChange(event, data, type){
-        let tempConfig = this.props.config
-        tempConfig[type] = data.value
+        let tempConfig = this.props.config;
+        tempConfig[type] = data.value;
+        tempConfig[type+'Label'] = data.text;
         await this.props.handleParentState("config", tempConfig, "groupAndSortRecalc")
     }
 
@@ -25,14 +28,18 @@ export default class MenuBar extends React.Component {
     }
 
     render() {
-        const groupOptions = [
-            { key: 1, text: 'NR Account', value: 'accountName' },
-            { key: 2, text: 'Cloud Account', value: 'providerAccountName' },
-            { key: 3, text: 'Applications', value: 'apmApplicationNames' },
-            { key: 4, text: 'Region', value: 'region' },
-            { key: 5, text: 'Instance Type', value: 'instanceType' },
-            { key: 6, text: 'Suggested Instance Type', value: 'suggestedInstanceType' }
+        const standardGroupOptions = [
+            { attributeName: 'accountName', displayName: 'NR Account' },
+            { attributeName: 'providerAccountName', displayName: 'Cloud Account' },
+            { attributeName: 'apmApplicationNames', displayName: 'Applications' },
+            { attributeName: 'region', displayName: 'Region' },
+            { attributeName: 'instanceType', displayName: 'Instance Type' },
+            { attributeName: 'suggestedInstanceType', displayName: 'Suggested Instance Type' }
         ]
+
+        const cloudLabelGroupOptions = this.props.cloudLabelGroups.map((group) => {
+            return { attributeName: group, displayName: cloudLabelAttributeToDisplayName(group) }
+        });
 
         const sortOptions = [
             { key: 1, text: 'Saving Value', value: 'saving' },
@@ -46,11 +53,23 @@ export default class MenuBar extends React.Component {
         return(
             <Menu inverted={false} className="menu-bar">
                 <Menu.Item>Group By:</Menu.Item>
-                <Dropdown 
-                    options={groupOptions} simple item
-                    onChange={(event, data)=>{this.handleDropdownChange(event, data, "groupBy")}} 
+                <Dropdown item
                     value={this.props.config.groupBy || "accountName"}
-                />
+                    text={this.props.config.groupByLabel || "NR Account"}
+                >
+                    <Dropdown.Menu>
+                        {standardGroupOptions.map(group => {
+                            return <Dropdown.Item key={group.attributeName} value={group.attributeName} text={group.displayName} onClick={(event, data)=>{this.handleDropdownChange(event, data, "groupBy")}} />
+                        })}
+                        <Dropdown.Divider/>
+                        <Dropdown.Header icon="cloud" content="Cloud Tags/Labels"/>
+                        <Dropdown.Menu scrolling>
+                            {cloudLabelGroupOptions.map(group => {
+                                return <Dropdown.Item key={group.attributeName} value={group.attributeName} text={group.displayName} onClick={(event, data)=>{this.handleDropdownChange(event, data, "groupBy")}} />
+                            })}
+                        </Dropdown.Menu>
+                    </Dropdown.Menu>
+                </Dropdown>
                 <Menu.Item>{this.props.instanceLength}</Menu.Item>
 
                 <Menu.Item>Sort By:</Menu.Item>

--- a/nerdlets/shared/lib/utils.js
+++ b/nerdlets/shared/lib/utils.js
@@ -40,11 +40,18 @@ export const accountsQuery = gql`{
   }
 }`
 
-export const getInstanceData = (accountId) => {
+export const isCloudLabel = (attributeName) => /label\..+/.test(attributeName);
+
+export const cloudLabelAttributeToDisplayName = (attributeName) => attributeName.match(/label\.(.+)/)[1];
+
+export const getSystemSampleKeySetNRQL = 'SELECT keyset() FROM SystemSample';
+
+export const getInstanceData = (accountId, cloudLabelAttributes) => {
+  let cloudLabelSelectString = ((cloudLabelAttributes.length > 0) ? ", " : "") + cloudLabelAttributes.map(att => `latest(\`${att}\`) as '${att}'`).join(', ');
   return gql`{
     actor {
       account(id: ${accountId}) {
-        system: nrql(query: "FROM SystemSample SELECT latest(timestamp) as 'timestamp', latest(apmApplicationNames) as 'apmApplicationNames', latest(providerAccountName) as 'providerAccountName', latest(entityGuid) as 'entityGuid', latest(awsRegion) as 'awsRegion', latest(regionName) as 'regionName', latest(zone) as 'zone', latest(coreCount) as 'numCpu', latest(memoryTotalBytes) as 'memTotalBytes', latest(operatingSystem) as 'operatingSystem', latest(ec2InstanceType) as 'ec2InstanceType', max(cpuPercent) as 'maxCpuPercent', max(memoryUsedBytes/memoryTotalBytes)*100 as 'maxMemoryPercent', latest(instanceType) as 'instanceType', latest(ec2InstanceId) as 'ec2InstanceId' FACET hostname WHERE coreCount is not null and ((instanceType is not null AND instanceType != 'unknown') OR ec2InstanceType is not null) LIMIT 2000 since 1 week ago", timeout: 30000) {
+        system: nrql(query: "FROM SystemSample SELECT latest(timestamp) as 'timestamp', latest(apmApplicationNames) as 'apmApplicationNames', latest(providerAccountName) as 'providerAccountName', latest(entityGuid) as 'entityGuid', latest(awsRegion) as 'awsRegion', latest(regionName) as 'regionName', latest(zone) as 'zone', latest(coreCount) as 'numCpu', latest(memoryTotalBytes) as 'memTotalBytes', latest(operatingSystem) as 'operatingSystem', latest(ec2InstanceType) as 'ec2InstanceType', max(cpuPercent) as 'maxCpuPercent', max(memoryUsedBytes/memoryTotalBytes)*100 as 'maxMemoryPercent', latest(instanceType) as 'instanceType', latest(ec2InstanceId) as 'ec2InstanceId'${cloudLabelSelectString} FACET hostname WHERE coreCount is not null and ((instanceType is not null AND instanceType != 'unknown') OR ec2InstanceType is not null) LIMIT 2000 since 1 week ago", timeout: 30000) {
           results
         }
         network: nrql(query: "FROM NetworkSample SELECT latest(timestamp) as 'timestamp', latest(entityGuid) as 'entityGuid', max(receiveBytesPerSecond) as 'receiveBytesPerSecond', max(transmitBytesPerSecond) as 'transmitBytesPerSecond' FACET hostname WHERE ((instanceType is not null AND instanceType != 'unknown') OR ec2InstanceType is not null) LIMIT 2000 since 1 week ago", timeout: 30000) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "uuidStaging": "35e0f5ec-7e97-4d04-ba95-1779c936878c",
     "sdkVersion": 2,
     "uuidLGA": "eb714647-7de2-4ed0-9ec8-2e18e2ae6385",
-    "uuid": "e30b3b37-db06-439a-b030-cd5bcf7ee323"
+    "uuid": "f2217556-fe75-446d-bb3a-b60941261394"
   },
   "bugs": {
     "email": "opensource@newrelic.com"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "nr1-cloud-optimize",
   "description": "Nerdpack cloud-optimize",
-  "version": "0.3.0",
+  "version": "0.2.3",
   "scripts": {
     "start": "nr1 nerdpack:serve",
     "test": "exit 0"
@@ -12,7 +12,7 @@
     "uuidStaging": "35e0f5ec-7e97-4d04-ba95-1779c936878c",
     "sdkVersion": 2,
     "uuidLGA": "eb714647-7de2-4ed0-9ec8-2e18e2ae6385",
-    "uuid": "f2217556-fe75-446d-bb3a-b60941261394"
+    "uuid": "e30b3b37-db06-439a-b030-cd5bcf7ee323"
   },
   "bugs": {
     "email": "opensource@newrelic.com"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "nr1-cloud-optimize",
   "description": "Nerdpack cloud-optimize",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "scripts": {
     "start": "nr1 nerdpack:serve",
     "test": "exit 0"


### PR DESCRIPTION
* Gets all of the cloud attributes (currently, those prefixed with `label.`) within each account from `SystemSample` via `keySet()`
* adds them to the NerdGraph SystemSample query so they will be part of each Instance's data.
* adds them Globally to the Group By dropdown

<img width="812" alt="Screen Shot 2019-11-07 at 6 59 01 PM" src="https://user-images.githubusercontent.com/1082112/68438152-2a501b00-0191-11ea-9b33-b85304ea70a0.png">
