### PR TITLE
Add Entity as a group option

### DIFF
--- a/nerdlets/cloud-optimize-nerdlet/components/menuBar.js
+++ b/nerdlets/cloud-optimize-nerdlet/components/menuBar.js
@@ -34,7 +34,8 @@ export default class MenuBar extends React.Component {
             { attributeName: 'apmApplicationNames', displayName: 'Applications' },
             { attributeName: 'region', displayName: 'Region' },
             { attributeName: 'instanceType', displayName: 'Instance Type' },
-            { attributeName: 'suggestedInstanceType', displayName: 'Suggested Instance Type' }
+            { attributeName: 'suggestedInstanceType', displayName: 'Suggested Instance Type' },
+            { attributeName: 'entityName', displayName: 'Entity' }
         ]
 
         const cloudLabelGroupOptions = this.props.cloudLabelGroups.map((group) => {


### PR DESCRIPTION
Just adding in as a group option, after previous PR to display it in the optimisation views.
Not sure how useful it would be for others (feel free to reject it), but we deploy to auto scale groups which have the entity as the name, so if we see 7 out of 8 instances can be optimised then it should be a good indication that the instance type for that "group" can be re-sized