### PR TITLE
Fix invalid link in README to Contributors Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ Issues and enhancement requests can be submitted in the [Issues tab of this repo
 
 ## Contributing
 
-Contributions are welcome (and if you submit a Enhancement Request, expect to be invited to contribute it yourself :grin:). Please review our [Contributors Guide](blob/master/CONTRIBUTING.md).
+Contributions are welcome (and if you submit a Enhancement Request, expect to be invited to contribute it yourself :grin:). Please review our [Contributors Guide](./CONTRIBUTING.md).
 
 Keep in mind that when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. If you'd like to execute our corporate CLA, or if you have any questions, please drop us an email at opensource@newrelic.com.


### PR DESCRIPTION
Hello! It looks like the CONTRIBUTING link in the README is resulting in a 404. This pull request replaces the (incorrect?) absolute URL with a relative one, fixing the 404 while still maintaining compatibility with other markdown engines.