### PR TITLE
Include CPU and Memory values of Suggested Instance in Optimisation Candidates

### DIFF
--- a/nerdlets/cloud-optimize-nerdlet/components/optimizationCandidates.js
+++ b/nerdlets/cloud-optimize-nerdlet/components/optimizationCandidates.js
@@ -162,6 +162,16 @@ export default class OptimizationCandidates extends React.Component {
                                 suggestedInstanceType
                                 </Table.HeaderCell>
                                 <Table.HeaderCell
+                                    sorted={this.state.column === 'suggestedInstanceTypeNumCPU' ? this.state.direction : null}
+                                    onClick={()=>this.handleTableSort('suggestedInstanceTypeNumCPU')}>
+                                suggestedInstanceTypeNumCPU
+                                </Table.HeaderCell>
+                                <Table.HeaderCell
+                                    sorted={this.state.column === 'suggestedInstanceTypeMemGB' ? this.state.direction : null}
+                                    onClick={()=>this.handleTableSort('suggestedInstanceTypeMemGB')}>
+                                suggestedInstanceTypeMemGB
+                                </Table.HeaderCell>
+                                <Table.HeaderCell
                                     sorted={this.state.column === 'instancePrice2' ? this.state.direction : null}
                                     onClick={()=>this.handleTableSort('instancePrice2')}>
                                     suggested price /m
@@ -196,6 +206,8 @@ export default class OptimizationCandidates extends React.Component {
                                             <Table.Cell style={{textAlign:"center"}}>
                                              {tempSuggestions.length > 0 ?  this.renderSuggestionsModal(instance.suggestedInstanceType, tempSuggestions) : instance.suggestedInstanceType}
                                             </Table.Cell>
+                                            <Table.Cell>{instance.suggestedInstanceTypeNumCPU}</Table.Cell>
+                                            <Table.Cell>{instance.suggestedInstanceTypeMemGB}</Table.Cell>
                                             <Table.Cell>{(instance.instancePrice2 * monthlyHours).toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}</Table.Cell>
                                             <Table.Cell>{(instance.saving * monthlyHours).toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}</Table.Cell>
                                         </Table.Row>

--- a/nerdlets/cloud-optimize-nerdlet/components/optimizationCandidates.js
+++ b/nerdlets/cloud-optimize-nerdlet/components/optimizationCandidates.js
@@ -80,6 +80,8 @@ export default class OptimizationCandidates extends React.Component {
             	instanceData.matchedInstanceType = instanceData.matchedInstance['type']
             	instanceData.matchedInstanceCategory = instanceData.matchedInstance['category']
             	instanceData.matchedInstancePrice = instanceData.matchedInstance['onDemandPrice']
+                instanceData.matchedNumCPUe = instanceData.matchedInstance['cpusPerVm']
+                instanceData.matchedMemGB = instanceData.matchedInstance['memPerVm']
               }
             for(let z=0;z<Object.keys(instanceData).length;z++){
                 if(Array.isArray(instanceData[Object.keys(instanceData)[z]])){

--- a/nerdlets/shared/lib/processor.js
+++ b/nerdlets/shared/lib/processor.js
@@ -49,6 +49,8 @@ export const processSample = (account, sample, config, networkSamples, cloudData
     if(sample.suggestions){
       let optimizedSuggestion = sample.suggestions.suggested
       sample.suggestedInstanceType = optimizedSuggestion.instanceType
+      sample.suggestedMemGB = Math.round(optimizedSuggestion.memTotalBytes/1024/1024/1024)
+      sample.suggestedNumCpu = parseFloat(optimizedSuggestion.numCpu)
       sample.instancePrice2 = parseFloat(optimizedSuggestion.price) * config.discountMultiplier
       sample.saving = sample.instancePrice1 - sample.instancePrice2
     }
@@ -74,6 +76,8 @@ export const groupInstances = (data, type, val, state, forceGroupBy) => {
                 sample.suggestions = null
                 sample.suggestion = null
                 tempData[i].instancePrice1 = 0
+                tempData[i].suggestedMemGB = 0
+                tempData[i].suggestedNumCpu = 0
                 tempData[i].instancePrice2 = 0
                 tempData[i].saving = 0
                 //
@@ -85,6 +89,8 @@ export const groupInstances = (data, type, val, state, forceGroupBy) => {
                 if(tempData[i].suggestions){    
                     let optimizedSuggestion = tempData[i].suggestions.suggested
                     tempData[i].suggestedInstanceType = optimizedSuggestion.instanceType
+                    tempData[i].suggestedMemGB = Math.round(optimizedSuggestion.memTotalBytes/1024/1024/1024)
+                    tempData[i].suggestedNumCpu = parseFloat(optimizedSuggestion.numCpu)
                     tempData[i].instancePrice2 = parseFloat(optimizedSuggestion.price) * config.discountMultiplier
                     tempData[i].saving = tempData[i].instancePrice1 - tempData[i].instancePrice2
                 }else{


### PR DESCRIPTION
Issue #30 

I haven't tested these changes out yet - wanted to check your thoughts on it first @Kav91 

Let me know what you think, if it sounds sensible then perhaps it could be useful for issue 13 aswell (although t's probably getting close to a point where there are too many columns on the view), if we have the suggested CPU we could have a guess at the maxCPU and Memory based on the original instances and give some kind of projection? eg. something simple like if it was 40% on 4 CPU then it might be 80% on a 2 CPU suggested Instance, and 25% Memory usage on a 32GB might be 50% on a 16GB instance type.