### PR TITLE
Non-optimized instances no longer included as potential savings.

### DIFF
--- a/nerdlets/cloud-optimize-core/strategies/instances.js
+++ b/nerdlets/cloud-optimize-core/strategies/instances.js
@@ -189,7 +189,12 @@ export const addInstanceCostTotal = (entityMetricTotals, e) => {
     }
     // end optimized results
 
-    if (!e.unableToGetOnPremPrice && matchedPrice > 0 && optimizedPrice >= 0) {
+    if (
+      !e.unableToGetOnPremPrice &&
+      matchedPrice > 0 &&
+      optimizedPrice !== null &&
+      optimizedPrice >= 0
+    ) {
       potentialSavings = matchedPrice - optimizedPrice;
       entityMetricTotals.instances.potentialSavings += potentialSavings;
       e.potentialSavings = potentialSavings;
@@ -197,7 +202,13 @@ export const addInstanceCostTotal = (entityMetricTotals, e) => {
       e.optimizedPrice = optimizedPrice;
 
       e.currentSpend = matchedPrice;
-      e.optimizedPrice = optimizedPrice;
+    } else if (
+      !e.unableToGetOnPremPrice &&
+      matchedPrice > 0 &&
+      optimizedPrice === null
+    ) {
+      // assign current cost for non-optimized instances
+      e.optimizedSpend = matchedPrice;
     }
   }
 


### PR DESCRIPTION
Nulls, when used in a logical comparison are assigned the value 0, so a check is required to ensure optimized price is not null. This had the effect of assigning instances that are not flagged for optimization to the potential savings.

Additionally the optimizedSpend needs to be assigned to each instance for the group tiles and summary bar totals to be calculated correctly.

Fixes #53 

