### PR TITLE
chore: removed labels from dropdown components

### DIFF
--- a/nerdlets/cloud-optimize-core/components/workload-costs/add-cost.js
+++ b/nerdlets/cloud-optimize-core/components/workload-costs/add-cost.js
@@ -6,7 +6,7 @@ import { writeEntityDocument } from '../../../shared/lib/utils';
 const periods = Array.from(Array(61).keys());
 periods.shift();
 
-const periodOptions = periods.map(p => ({
+const periodOptions = periods.map((p) => ({
   key: p,
   text: p,
   value: p
@@ -96,7 +96,7 @@ export default class AddCost extends React.PureComponent {
       <DataConsumer>
         {({ workloadEntities, selectedWorkload, getWorkloadDocs }) => {
           const dc = workloadEntities.filter(
-            d => d.name === selectedWorkload
+            (d) => d.name === selectedWorkload
           )[0];
 
           return (
@@ -143,7 +143,6 @@ export default class AddCost extends React.PureComponent {
                       <Dropdown
                         className="singledrop"
                         width="8"
-                        label=""
                         placeholder="Months"
                         search
                         selection

--- a/nerdlets/cloud-optimize-core/components/workload-costs/index.js
+++ b/nerdlets/cloud-optimize-core/components/workload-costs/index.js
@@ -1,4 +1,4 @@
-/* eslint 
+/* eslint
 no-console: 0,
 no-async-promise-executor: 0
 */
@@ -88,7 +88,6 @@ export default class WorkloadCosts extends React.PureComponent {
                       <Dropdown
                         style={{ width: '250px' }}
                         className="singledrop"
-                        label="Select Workload"
                         placeholder="Select Workload"
                         search
                         selection
@@ -142,7 +141,6 @@ export default class WorkloadCosts extends React.PureComponent {
                           <Dropdown
                             style={{ width: '250px' }}
                             className="singledrop"
-                            label="Select Cost Category"
                             placeholder="Select Cost Category"
                             search
                             selection


### PR DESCRIPTION
This PR includes the removal of labels from the dropdown components to pass repolinter deprecation checks and also some prettier linter catches. 